### PR TITLE
Enable spawn belt to put second item in chest onto belt line 2

### DIFF
--- a/spawn-belt/control.lua
+++ b/spawn-belt/control.lua
@@ -212,7 +212,6 @@ end
 
 function tick_belts(tick)
   for k, belt in ipairs(belts) do
-    itemtwo = nil;
     if belt.entity.valid ~= true then
       table.remove(belts, k);
       destroy_globals();
@@ -224,7 +223,7 @@ function tick_belts(tick)
           chest = find_entity_before(belt, "container");
           if chest ~= nil then
             belt.item = get_chest_item(1, chest);
-            itemtwo = get_chest_item(2, chest);
+            belt.itemtwo = get_chest_item(2, chest);
           end
         end
 
@@ -248,8 +247,8 @@ function tick_belts(tick)
           end
           line2 = belt.entity.get_transport_line(2);
           if line2.can_insert_at_back() then
-            if itemtwo then
-              line2.insert_at_back({name = itemtwo});
+            if belt.itemtwo then
+              line2.insert_at_back({name = belt.itemtwo});
             else
               line2.insert_at_back({name = belt.item});
             end

--- a/spawn-belt/control.lua
+++ b/spawn-belt/control.lua
@@ -161,14 +161,14 @@ function find_entity_after(belt, type)
   return nil;
 end
 
-function get_chest_item(chest)
+function get_chest_item(num, chest)
   inventory = chest.get_inventory(defines.inventory.chest);
   if inventory ~= nil
   and inventory.valid == true 
   and inventory.is_empty() == false 
-  and inventory[1].valid == true
-  and inventory[1].valid_for_read == true then
-    return inventory[1].name;
+  and inventory[num].valid == true
+  and inventory[num].valid_for_read == true then
+    return inventory[num].name;
   end
   return nil;
 end
@@ -212,6 +212,7 @@ end
 
 function tick_belts(tick)
   for k, belt in ipairs(belts) do
+    itemtwo = nil;
     if belt.entity.valid ~= true then
       table.remove(belts, k);
       destroy_globals();
@@ -222,7 +223,8 @@ function tick_belts(tick)
         if tick.tick % entity_detection_rate == 0 then
           chest = find_entity_before(belt, "container");
           if chest ~= nil then
-            belt.item = get_chest_item(chest);
+            belt.item = get_chest_item(1, chest);
+            itemtwo = get_chest_item(2, chest);
           end
         end
 
@@ -246,7 +248,11 @@ function tick_belts(tick)
           end
           line2 = belt.entity.get_transport_line(2);
           if line2.can_insert_at_back() then
-            line2.insert_at_back({name = belt.item});
+            if itemtwo then
+              line2.insert_at_back({name = itemtwo});
+            else
+              line2.insert_at_back({name = belt.item});
+            end
           end
         end
       elseif belt.entity.name == "void-belt" then


### PR DESCRIPTION
First of all, I love this mod! Thanks for creating it! I thought it would be even better if the spawn belt would use the second slot in the chest to spawn that item onto the second belt line. I've tested the changes and fixed them until it works. I hope you don't mind my contributing and that this feature makes it into the mod.